### PR TITLE
Add a central setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,15 @@
 import os, sys
 import glob
 
-packages = glob.glob('*wheat')
+packages = '''
+respi-wheat
+farquhar-wheat
+elong-wheat
+growth-wheat
+senesc-wheat
+cn-wheat
+fspm-wheat
+'''.split()
 
 def sh(cmd):
     return os.system(cmd)

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,22 @@
+import os, sys
+import glob
+
+packages = glob.glob('*wheat')
+
+def sh(cmd):
+    return os.system(cmd)
+
+def apply(*args):
+    status = 0
+    cmd = 'python setup.py %s'%(' '.join(*args))
+    for pkg in packages:
+        os.chdir(pkg)
+        st = sh(cmd)
+        status = max(st, status)
+        os.chdir('..')
+    return status
+if __name__ == "__main__": 
+    #print('packages', packages)
+    #print('Args', sys.argv[1:])
+    status = apply(sys.argv[1:])
+    


### PR DESCRIPTION
Fix issue #2 
I create a setup.py script that calls the different setup of the different packages.
@rbarillot : Is there an order or dependency to run the packages?

Moreover, there is a need to review all the sub  setup.py. They try to install dependencies (numpy, pandas) but do not consider the underlying package manager (eg conda, pip, ...).
Dependencies have to be install separetly from the setup.py.